### PR TITLE
feat(color): better picker, shortcuts, tabindex

### DIFF
--- a/client/src/components/Art.vue
+++ b/client/src/components/Art.vue
@@ -3,7 +3,11 @@
     <tbody>
       <tr v-for="column in columns" :key="column">
         <td
+          :tabindex="0"
           @click.meta="pickColor"
+          @keydown.enter="
+            (e) => !readonly && paint(row, column, color, e.target)
+          "
           @click.exact="(e) => !readonly && paint(row, column, color, e.target)"
           v-for="row in rows"
           :key="row"
@@ -21,12 +25,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, withDefaults } from "vue";
+import { ref, watchEffect, withDefaults } from "vue";
 import type { Ref } from "vue";
 
 const props = withDefaults(
   defineProps<{
-    artboard: ArtBoard;
+    artboard: ArtBoard | null;
     color: string;
     readonly?: boolean;
   }>(),
@@ -35,21 +39,29 @@ const props = withDefaults(
   }
 );
 
-export interface ArtBoard {
+export type ArtBoard = {
   grid: { [i: number]: { [j: number]: { color: string } } } | undefined;
   timestamp: number;
-}
+};
 
 const emit = defineEmits(["update"]);
 const columns = 20;
 const rows = 20;
+
 const board: Ref<ArtBoard> = ref({
-  grid: props?.artboard.grid || {},
+  grid: props?.artboard?.grid || {},
   timestamp: Date.now(),
 });
 
+watchEffect(() => {
+  board.value.grid = props.artboard?.grid;
+});
+
 function rgbToHex(r: string, g: string, b: string) {
-  const hex = (i: string) => parseInt(i).toString(16);
+  const hex = (i: string) => {
+    const hex = parseInt(i).toString(16);
+    return hex.length == 1 ? `0${hex}` : hex;
+  };
   return "#" + hex(r) + hex(g) + hex(b);
 }
 

--- a/client/src/components/ColorPicker.vue
+++ b/client/src/components/ColorPicker.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <input
+      class="
+        focus:ring-blue-600
+        focus:ring-4
+        focus:ring-offset-2
+        focus:ring-opacity-75
+        transition
+        duration-200
+        ease-in-out
+      "
+      type="color"
+      :value="modelValue"
+      @input="$emit('update:modelValue', $event.target.value)"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+export default {
+  props: ["modelValue"],
+  emits: ["update:modelValue"],
+};
+</script>
+
+<style scoped>
+input {
+  border-radius: 10%;
+  height: 30px;
+  width: 30px;
+  border: 1px solid darkgrey;
+  outline: none;
+  -webkit-appearance: none;
+}
+input::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+input::-webkit-color-swatch {
+  border: none;
+  border-radius: 10%;
+}
+</style>

--- a/client/src/components/TheNav.vue
+++ b/client/src/components/TheNav.vue
@@ -1,7 +1,9 @@
 <template>
-  <nav class="flex w-content">
+  <nav class="flex w-content font-mono">
     <ol class="flex my-4">
-      <li><router-link :to="{ name: 'Home' }">Home</router-link></li>
+      <li>
+        <router-link :to="{ name: 'Home' }">Home</router-link>
+      </li>
       <li class="ml-4">
         <router-link :to="{ name: 'Archive' }">Archive</router-link>
       </li>

--- a/client/src/views/About.vue
+++ b/client/src/views/About.vue
@@ -1,24 +1,34 @@
 <template>
-  <section class="font-mono justify-start w-content">
-    <p class="mb-10">
-      A collaborative pixel art web tool for creating new art every day. The
-      pixel artboard is wiped clean each day, and anyone can add pixels to the
-      board. There is no guarantee your pixel will stay the same and each new
-      day resets the board. After a day has passed, the art is frozen and can be
-      accessed via the
-      <router-link
-        class="text-blue-600 font-bold underline"
-        :to="{ name: 'Archive' }"
-        >archive</router-link
-      >. Code is hosted on GitHub
-      <a
-        target="_blank"
-        class="text-blue-600 font-bold underline"
-        href="https://github.com/darrenjennings/workart"
-        >here</a
-      >.
-    </p>
-    <div class="mb-2">
+  <div class="w-content font-mono">
+    <section>
+      <h1 class="hidden">About</h1>
+      <p class="mb-10">
+        A collaborative pixel art web tool for creating new art every day. The
+        pixel artboard is wiped clean each day, and anyone can add pixels to the
+        board. There is no guarantee your pixel will stay the same and each new
+        day resets the board. After a day has passed, the art is frozen and can
+        be accessed via the
+        <router-link
+          class="text-blue-600 font-bold underline"
+          :to="{ name: 'Archive' }"
+          >archive</router-link
+        >. Code is hosted on GitHub
+        <a
+          target="_blank"
+          class="text-blue-600 font-bold underline"
+          href="https://github.com/darrenjennings/workart"
+          >here</a
+        >.
+      </p>
+    </section>
+    <section class="mt-10">
+      <h2>Shortcuts</h2>
+      <div class="mt-2">
+        <kbd>Cmd</kbd> + <kbd>Click</kbd> The current color will be changed to
+        the cell being moused over.
+      </div>
+    </section>
+    <div class="mt-10">
       Created with <span class="font-sans">&#10084;</span> by
       <a
         target="_blank"
@@ -27,5 +37,22 @@
         >Darren Jennings</a
       >
     </div>
-  </section>
+  </div>
 </template>
+
+<style scoped>
+kbd {
+  background-color: #eee;
+  border-radius: 3px;
+  border: 1px solid #b4b4b4;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2),
+    0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
+  color: #333;
+  display: inline-block;
+  font-size: 0.85em;
+  font-weight: 700;
+  line-height: 1;
+  padding: 2px 4px;
+  white-space: nowrap;
+}
+</style>


### PR DESCRIPTION
Add a better looking color picker that is more prominent and has a better click radius.
Add tabindex for focus tabbing and hitting "enter" key to paint a cell.
Add shortcuts section to about so users know they can command + click a cell to get the color.

![image](https://user-images.githubusercontent.com/5770711/133896757-d3bf0da8-7421-45ac-862c-795f2b31b64f.png)
![image](https://user-images.githubusercontent.com/5770711/133896783-ec20bd57-db2e-4ece-8da5-d6172e763c57.png)

